### PR TITLE
Ensure app config file is always closed

### DIFF
--- a/pkg/api/v1/config.go
+++ b/pkg/api/v1/config.go
@@ -22,6 +22,7 @@ func loadConfig(filename string) (*AppConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer jsonFile.Close()
 	data, err := ioutil.ReadAll(jsonFile)
 	if err != nil {
 		return nil, err
@@ -30,7 +31,6 @@ func loadConfig(filename string) (*AppConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer jsonFile.Close()
 	return &appConfig, nil
 }
 


### PR DESCRIPTION
The app config file will currently not be closed if reading or unmarshaling it from JSON fails. Moving the `defer` statement to immediately after error-checking its opening should remove this edge case.