### PR TITLE
Add apiPath. Make LoadConfig a public method

### DIFF
--- a/pkg/api/v1/config.go
+++ b/pkg/api/v1/config.go
@@ -16,7 +16,7 @@ var PrivateDependencyEndpoints map[string]map[string]PrivateDependencyEndpoint
 var ObjectBuckets map[string]ObjectStoreBucket
 var KafkaServers []string
 
-func loadConfig(filename string) (*AppConfig, error) {
+func LoadConfig(filename string) (*AppConfig, error) {
 	var appConfig AppConfig
 	jsonFile, err := os.Open(filename)
 	if err != nil {
@@ -43,7 +43,7 @@ func init() {
 	if !IsClowderEnabled() {
 		return
 	}
-	loadedConfig, err := loadConfig(os.Getenv("ACG_CONFIG"))
+	loadedConfig, err := LoadConfig(os.Getenv("ACG_CONFIG"))
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/pkg/api/v1/config_test.go
+++ b/pkg/api/v1/config_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestClientLoad(t *testing.T) {
 	assert.NotNil(t, LoadedConfig, "Config didn't load in init()")
+	assert.Equal(t, "api-path", LoadedConfig.ApiPath, "APIPath not loaded")
 	assert.Len(t, LoadedConfig.Kafka.Brokers, 1, "Kafka brokers not loaded")
 	assert.Equal(t, 27015, *(LoadedConfig.Kafka.Brokers[0].Port), "Kafka port was not loaded")
 	assert.Contains(t, KafkaTopics, "originalName", "Kafka Topic not found")
@@ -50,7 +51,7 @@ func TestClientLoad(t *testing.T) {
 }
 
 func TestEmptyRDSCa(t *testing.T) {
-	cfg, err := loadConfig("../../../tests/nordsca.json")
+	cfg, err := LoadConfig("../../../tests/nordsca.json")
 	if err != nil {
 		log.Fatalf("can't load config: %s", err)
 	}

--- a/pkg/api/v1/config_test.go
+++ b/pkg/api/v1/config_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestClientLoad(t *testing.T) {
 	assert.NotNil(t, LoadedConfig, "Config didn't load in init()")
-	assert.Equal(t, "api-path", LoadedConfig.ApiPath, "APIPath not loaded")
 	assert.Len(t, LoadedConfig.Kafka.Brokers, 1, "Kafka brokers not loaded")
 	assert.Equal(t, 27015, *(LoadedConfig.Kafka.Brokers[0].Port), "Kafka port was not loaded")
 	assert.Contains(t, KafkaTopics, "originalName", "Kafka Topic not found")
@@ -25,6 +24,9 @@ func TestClientLoad(t *testing.T) {
 	assert.Equal(t, "http", string(LoadedConfig.FeatureFlags.Scheme), "Wrong feature flag scheme")
 
 	assert.Equal(t, "/foo/bar", *(LoadedConfig.TlsCAPath))
+
+	assert.Equal(t, "app1-api-path", DependencyEndpoints["app1"]["endpoint1"].ApiPath, "endpoint1 had wrong port")
+	assert.Equal(t, "app2-api-path", DependencyEndpoints["app2"]["endpoint2"].ApiPath, "endpoint2 had wrong port")
 
 	assert.Equal(t, 8000, DependencyEndpoints["app1"]["endpoint1"].Port, "endpoint had wrong port")
 	assert.Equal(t, "endpoint2", DependencyEndpoints["app2"]["endpoint2"].Name, "endpoint had wrong name")

--- a/pkg/api/v1/schema.json
+++ b/pkg/api/v1/schema.json
@@ -8,6 +8,10 @@
             "type": "object",
             "description": "ClowdApp deployment configuration for Clowder enabled apps.",
             "properties": {
+                "apiPath": {
+                    "description": "Defines the path used in the public web service",
+                    "type": "string"
+                },
                 "privatePort": {
                     "description": "Defines the private port that the app should be configured to listen on for API traffic.",
                     "type": "integer"

--- a/pkg/api/v1/schema.json
+++ b/pkg/api/v1/schema.json
@@ -8,10 +8,6 @@
             "type": "object",
             "description": "ClowdApp deployment configuration for Clowder enabled apps.",
             "properties": {
-                "apiPath": {
-                    "description": "Defines the path used in the public web service",
-                    "type": "string"
-                },
                 "privatePort": {
                     "description": "Defines the private port that the app should be configured to listen on for API traffic.",
                     "type": "integer"
@@ -472,13 +468,17 @@
                 "tlsPort": {
                     "description": "The TLS port of the dependent service.",
                     "type": "integer"
+                },
+                "apiPath": {
+                    "description": "The top level api path that the app should serve from /api/<apiPath>"
                 }
             },
             "required": [
                 "name",
                 "hostname",
                 "port",
-                "app"
+                "app",
+                "apiPath"
             ]
         },
         "PrivateDependencyEndpoint": {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -68,6 +68,9 @@ func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
 
 // ClowdApp deployment configuration for Clowder enabled apps.
 type AppConfig struct {
+	// Defines the path used in the public web service
+	ApiPath string `json:"apiPath"`
+
 	// Defines the path to the BOPURL.
 	BOPURL *string `json:"BOPURL,omitempty"`
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -71,9 +71,6 @@ type AppConfig struct {
 	// Defines the path to the BOPURL.
 	BOPURL *string `json:"BOPURL,omitempty" yaml:"BOPURL,omitempty" mapstructure:"BOPURL,omitempty"`
 
-	// API Path
-	ApiPath *string `json:"apiPath,omitempty" yaml:"apiPath,omitempty" mapstructure:"apiPath,omitempty"`
-
 	// Database corresponds to the JSON schema field "database".
 	Database *DatabaseConfig `json:"database,omitempty" yaml:"database,omitempty" mapstructure:"database,omitempty"`
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2,8 +2,8 @@
 
 package v1
 
-import "fmt"
 import "encoding/json"
+import "fmt"
 import "reflect"
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -13,10 +13,10 @@ func (j *TopicConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
+		return fmt.Errorf("field name in TopicConfig: required")
 	}
 	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
+		return fmt.Errorf("field requestedName in TopicConfig: required")
 	}
 	type Plain TopicConfig
 	var plain Plain
@@ -34,28 +34,28 @@ func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["adminPassword"]; !ok || v == nil {
-		return fmt.Errorf("field adminPassword: required")
+		return fmt.Errorf("field adminPassword in DatabaseConfig: required")
 	}
 	if v, ok := raw["adminUsername"]; !ok || v == nil {
-		return fmt.Errorf("field adminUsername: required")
+		return fmt.Errorf("field adminUsername in DatabaseConfig: required")
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in DatabaseConfig: required")
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
+		return fmt.Errorf("field name in DatabaseConfig: required")
 	}
 	if v, ok := raw["password"]; !ok || v == nil {
-		return fmt.Errorf("field password: required")
+		return fmt.Errorf("field password in DatabaseConfig: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
+		return fmt.Errorf("field port in DatabaseConfig: required")
 	}
 	if v, ok := raw["sslMode"]; !ok || v == nil {
-		return fmt.Errorf("field sslMode: required")
+		return fmt.Errorf("field sslMode in DatabaseConfig: required")
 	}
 	if v, ok := raw["username"]; !ok || v == nil {
-		return fmt.Errorf("field username: required")
+		return fmt.Errorf("field username in DatabaseConfig: required")
 	}
 	type Plain DatabaseConfig
 	var plain Plain
@@ -68,63 +68,60 @@ func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
 
 // ClowdApp deployment configuration for Clowder enabled apps.
 type AppConfig struct {
-	// Defines the path used in the public web service
-	ApiPath string `json:"apiPath"`
-
 	// Defines the path to the BOPURL.
-	BOPURL *string `json:"BOPURL,omitempty"`
+	BOPURL *string `json:"BOPURL,omitempty" yaml:"BOPURL,omitempty" mapstructure:"BOPURL,omitempty"`
 
 	// Database corresponds to the JSON schema field "database".
-	Database *DatabaseConfig `json:"database,omitempty"`
+	Database *DatabaseConfig `json:"database,omitempty" yaml:"database,omitempty" mapstructure:"database,omitempty"`
 
 	// Endpoints corresponds to the JSON schema field "endpoints".
-	Endpoints []DependencyEndpoint `json:"endpoints,omitempty"`
+	Endpoints []DependencyEndpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty" mapstructure:"endpoints,omitempty"`
 
 	// FeatureFlags corresponds to the JSON schema field "featureFlags".
-	FeatureFlags *FeatureFlagsConfig `json:"featureFlags,omitempty"`
+	FeatureFlags *FeatureFlagsConfig `json:"featureFlags,omitempty" yaml:"featureFlags,omitempty" mapstructure:"featureFlags,omitempty"`
 
 	// A set of configMap/secret hashes
-	HashCache *string `json:"hashCache,omitempty"`
+	HashCache *string `json:"hashCache,omitempty" yaml:"hashCache,omitempty" mapstructure:"hashCache,omitempty"`
 
 	// InMemoryDb corresponds to the JSON schema field "inMemoryDb".
-	InMemoryDb *InMemoryDBConfig `json:"inMemoryDb,omitempty"`
+	InMemoryDb *InMemoryDBConfig `json:"inMemoryDb,omitempty" yaml:"inMemoryDb,omitempty" mapstructure:"inMemoryDb,omitempty"`
 
 	// Kafka corresponds to the JSON schema field "kafka".
-	Kafka *KafkaConfig `json:"kafka,omitempty"`
+	Kafka *KafkaConfig `json:"kafka,omitempty" yaml:"kafka,omitempty" mapstructure:"kafka,omitempty"`
 
 	// Logging corresponds to the JSON schema field "logging".
-	Logging LoggingConfig `json:"logging"`
+	Logging LoggingConfig `json:"logging" yaml:"logging" mapstructure:"logging"`
 
 	// Metadata corresponds to the JSON schema field "metadata".
-	Metadata *AppMetadata `json:"metadata,omitempty"`
+	Metadata *AppMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata,omitempty"`
 
 	// Defines the path to the metrics server that the app should be configured to
 	// listen on for metric traffic.
-	MetricsPath string `json:"metricsPath"`
+	MetricsPath string `json:"metricsPath" yaml:"metricsPath" mapstructure:"metricsPath"`
 
 	// Defines the metrics port that the app should be configured to listen on for
 	// metric traffic.
-	MetricsPort int `json:"metricsPort"`
+	MetricsPort int `json:"metricsPort" yaml:"metricsPort" mapstructure:"metricsPort"`
 
 	// ObjectStore corresponds to the JSON schema field "objectStore".
-	ObjectStore *ObjectStoreConfig `json:"objectStore,omitempty"`
+	ObjectStore *ObjectStoreConfig `json:"objectStore,omitempty" yaml:"objectStore,omitempty" mapstructure:"objectStore,omitempty"`
 
 	// PrivateEndpoints corresponds to the JSON schema field "privateEndpoints".
-	PrivateEndpoints []PrivateDependencyEndpoint `json:"privateEndpoints,omitempty"`
+	PrivateEndpoints []PrivateDependencyEndpoint `json:"privateEndpoints,omitempty" yaml:"privateEndpoints,omitempty" mapstructure:"privateEndpoints,omitempty"`
 
 	// Defines the private port that the app should be configured to listen on for API
 	// traffic.
-	PrivatePort *int `json:"privatePort,omitempty"`
+	PrivatePort *int `json:"privatePort,omitempty" yaml:"privatePort,omitempty" mapstructure:"privatePort,omitempty"`
 
 	// Defines the public port that the app should be configured to listen on for API
 	// traffic.
-	PublicPort *int `json:"publicPort,omitempty"`
+	PublicPort *int `json:"publicPort,omitempty" yaml:"publicPort,omitempty" mapstructure:"publicPort,omitempty"`
 
 	// Defines the port CA path
-	TlsCAPath *string `json:"tlsCAPath,omitempty"`
+	TlsCAPath *string `json:"tlsCAPath,omitempty" yaml:"tlsCAPath,omitempty" mapstructure:"tlsCAPath,omitempty"`
 
 	// Deprecated: Use 'publicPort' instead.
-	WebPort *int `json:"webPort,omitempty"`
+	WebPort *int `json:"webPort,omitempty" yaml:"webPort,omitempty" mapstructure:"webPort,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -133,17 +130,20 @@ func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
+	if v, ok := raw["apiPath"]; !ok || v == nil {
+		return fmt.Errorf("field apiPath in DependencyEndpoint: required")
+	}
 	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
+		return fmt.Errorf("field app in DependencyEndpoint: required")
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in DependencyEndpoint: required")
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
+		return fmt.Errorf("field name in DependencyEndpoint: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
+		return fmt.Errorf("field port in DependencyEndpoint: required")
 	}
 	type Plain DependencyEndpoint
 	var plain Plain
@@ -161,16 +161,16 @@ func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
+		return fmt.Errorf("field app in PrivateDependencyEndpoint: required")
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in PrivateDependencyEndpoint: required")
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
+		return fmt.Errorf("field name in PrivateDependencyEndpoint: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
+		return fmt.Errorf("field port in PrivateDependencyEndpoint: required")
 	}
 	type Plain PrivateDependencyEndpoint
 	var plain Plain
@@ -188,13 +188,13 @@ func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in ObjectStoreConfig: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
+		return fmt.Errorf("field port in ObjectStoreConfig: required")
 	}
 	if v, ok := raw["tls"]; !ok || v == nil {
-		return fmt.Errorf("field tls: required")
+		return fmt.Errorf("field tls in ObjectStoreConfig: required")
 	}
 	type Plain ObjectStoreConfig
 	var plain Plain
@@ -232,10 +232,10 @@ func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
+		return fmt.Errorf("field name in ObjectStoreBucket: required")
 	}
 	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
+		return fmt.Errorf("field requestedName in ObjectStoreBucket: required")
 	}
 	type Plain ObjectStoreBucket
 	var plain Plain
@@ -249,13 +249,13 @@ func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
 // Arbitrary metadata pertaining to the application application
 type AppMetadata struct {
 	// Metadata pertaining to an application's deployments
-	Deployments []DeploymentMetadata `json:"deployments,omitempty"`
+	Deployments []DeploymentMetadata `json:"deployments,omitempty" yaml:"deployments,omitempty" mapstructure:"deployments,omitempty"`
 
 	// Name of the ClowdEnvironment this ClowdApp runs in
-	EnvName *string `json:"envName,omitempty"`
+	EnvName *string `json:"envName,omitempty" yaml:"envName,omitempty" mapstructure:"envName,omitempty"`
 
 	// Name of the ClowdApp
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -265,10 +265,10 @@ func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["image"]; !ok || v == nil {
-		return fmt.Errorf("field image: required")
+		return fmt.Errorf("field image in DeploymentMetadata: required")
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
+		return fmt.Errorf("field name in DeploymentMetadata: required")
 	}
 	type Plain DeploymentMetadata
 	var plain Plain
@@ -286,13 +286,13 @@ func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in FeatureFlagsConfig: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
+		return fmt.Errorf("field port in FeatureFlagsConfig: required")
 	}
 	if v, ok := raw["scheme"]; !ok || v == nil {
-		return fmt.Errorf("field scheme: required")
+		return fmt.Errorf("field scheme in FeatureFlagsConfig: required")
 	}
 	type Plain FeatureFlagsConfig
 	var plain Plain
@@ -310,7 +310,7 @@ func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type: required")
+		return fmt.Errorf("field type in LoggingConfig: required")
 	}
 	type Plain LoggingConfig
 	var plain Plain
@@ -328,10 +328,10 @@ func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in InMemoryDBConfig: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
+		return fmt.Errorf("field port in InMemoryDBConfig: required")
 	}
 	type Plain InMemoryDBConfig
 	var plain Plain
@@ -351,16 +351,16 @@ func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["accessKeyId"]; !ok || v == nil {
-		return fmt.Errorf("field accessKeyId: required")
+		return fmt.Errorf("field accessKeyId in CloudWatchConfig: required")
 	}
 	if v, ok := raw["logGroup"]; !ok || v == nil {
-		return fmt.Errorf("field logGroup: required")
+		return fmt.Errorf("field logGroup in CloudWatchConfig: required")
 	}
 	if v, ok := raw["region"]; !ok || v == nil {
-		return fmt.Errorf("field region: required")
+		return fmt.Errorf("field region in CloudWatchConfig: required")
 	}
 	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
-		return fmt.Errorf("field secretAccessKey: required")
+		return fmt.Errorf("field secretAccessKey in CloudWatchConfig: required")
 	}
 	type Plain CloudWatchConfig
 	var plain Plain
@@ -397,37 +397,37 @@ const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
 // Cloud Watch configuration
 type CloudWatchConfig struct {
 	// Defines the access key that the app should use for configuring CloudWatch.
-	AccessKeyId string `json:"accessKeyId"`
+	AccessKeyId string `json:"accessKeyId" yaml:"accessKeyId" mapstructure:"accessKeyId"`
 
 	// Defines the logGroup that the app should use for configuring CloudWatch.
-	LogGroup string `json:"logGroup"`
+	LogGroup string `json:"logGroup" yaml:"logGroup" mapstructure:"logGroup"`
 
 	// Defines the region that the app should use for configuring CloudWatch.
-	Region string `json:"region"`
+	Region string `json:"region" yaml:"region" mapstructure:"region"`
 
 	// Defines the secret key that the app should use for configuring CloudWatch.
-	SecretAccessKey string `json:"secretAccessKey"`
+	SecretAccessKey string `json:"secretAccessKey" yaml:"secretAccessKey" mapstructure:"secretAccessKey"`
 }
 
 // Broker Configuration
 type BrokerConfig struct {
 	// Authtype corresponds to the JSON schema field "authtype".
-	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty"`
+	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty" yaml:"authtype,omitempty" mapstructure:"authtype,omitempty"`
 
 	// Cacert corresponds to the JSON schema field "cacert".
-	Cacert *string `json:"cacert,omitempty"`
+	Cacert *string `json:"cacert,omitempty" yaml:"cacert,omitempty" mapstructure:"cacert,omitempty"`
 
 	// Hostname corresponds to the JSON schema field "hostname".
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// Port corresponds to the JSON schema field "port".
-	Port *int `json:"port,omitempty"`
+	Port *int `json:"port,omitempty" yaml:"port,omitempty" mapstructure:"port,omitempty"`
 
 	// Sasl corresponds to the JSON schema field "sasl".
-	Sasl *KafkaSASLConfig `json:"sasl,omitempty"`
+	Sasl *KafkaSASLConfig `json:"sasl,omitempty" yaml:"sasl,omitempty" mapstructure:"sasl,omitempty"`
 
 	// SecurityProtocol corresponds to the JSON schema field "securityProtocol".
-	SecurityProtocol *string `json:"securityProtocol,omitempty"`
+	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -437,7 +437,7 @@ func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in BrokerConfig: required")
 	}
 	type Plain BrokerConfig
 	var plain Plain
@@ -455,10 +455,10 @@ func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["brokers"]; !ok || v == nil {
-		return fmt.Errorf("field brokers: required")
+		return fmt.Errorf("field brokers in KafkaConfig: required")
 	}
 	if v, ok := raw["topics"]; !ok || v == nil {
-		return fmt.Errorf("field topics: required")
+		return fmt.Errorf("field topics in KafkaConfig: required")
 	}
 	type Plain KafkaConfig
 	var plain Plain
@@ -472,73 +472,76 @@ func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
 // Database Configuration
 type DatabaseConfig struct {
 	// Defines the pgAdmin password.
-	AdminPassword string `json:"adminPassword"`
+	AdminPassword string `json:"adminPassword" yaml:"adminPassword" mapstructure:"adminPassword"`
 
 	// Defines the pgAdmin username.
-	AdminUsername string `json:"adminUsername"`
+	AdminUsername string `json:"adminUsername" yaml:"adminUsername" mapstructure:"adminUsername"`
 
 	// Defines the hostname of the database configured for the ClowdApp.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// Defines the database name.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
 	// Defines the password for the standard user.
-	Password string `json:"password"`
+	Password string `json:"password" yaml:"password" mapstructure:"password"`
 
 	// Defines the port of the database configured for the ClowdApp.
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
 	// Defines the CA used to access the database.
-	RdsCa *string `json:"rdsCa,omitempty"`
+	RdsCa *string `json:"rdsCa,omitempty" yaml:"rdsCa,omitempty" mapstructure:"rdsCa,omitempty"`
 
 	// Defines the postgres SSL mode that should be used.
-	SslMode string `json:"sslMode"`
+	SslMode string `json:"sslMode" yaml:"sslMode" mapstructure:"sslMode"`
 
 	// Defines a username with standard access to the database.
-	Username string `json:"username"`
+	Username string `json:"username" yaml:"username" mapstructure:"username"`
 }
 
 // Dependent service connection info
 type DependencyEndpoint struct {
+	// The top level api path that the app should serve from /api/<apiPath>
+	ApiPath interface{} `json:"apiPath" yaml:"apiPath" mapstructure:"apiPath"`
+
 	// The app name of the ClowdApp hosting the service.
-	App string `json:"app"`
+	App string `json:"app" yaml:"app" mapstructure:"app"`
 
 	// The hostname of the dependent service.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// The PodSpec name of the dependent service inside the ClowdApp.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
 	// The port of the dependent service.
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
 	// The TLS port of the dependent service.
-	TlsPort *int `json:"tlsPort,omitempty"`
+	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
 }
 
 // Deployment Metadata
 type DeploymentMetadata struct {
 	// Image used by deployment
-	Image string `json:"image"`
+	Image string `json:"image" yaml:"image" mapstructure:"image"`
 
 	// Name of deployment
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 }
 
 // Feature Flags Configuration
 type FeatureFlagsConfig struct {
 	// Defines the client access token to use when connect to the FeatureFlags server
-	ClientAccessToken *string `json:"clientAccessToken,omitempty"`
+	ClientAccessToken *string `json:"clientAccessToken,omitempty" yaml:"clientAccessToken,omitempty" mapstructure:"clientAccessToken,omitempty"`
 
 	// Defines the hostname for the FeatureFlags server
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// Defines the port for the FeatureFlags server
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
 	// Details the scheme to use for FeatureFlags http/https
-	Scheme FeatureFlagsConfigScheme `json:"scheme"`
+	Scheme FeatureFlagsConfigScheme `json:"scheme" yaml:"scheme" mapstructure:"scheme"`
 }
 
 type FeatureFlagsConfigScheme string
@@ -549,115 +552,115 @@ const FeatureFlagsConfigSchemeHttps FeatureFlagsConfigScheme = "https"
 // In Memory DB Configuration
 type InMemoryDBConfig struct {
 	// Defines the hostname for the In Memory DB server configuration.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// Defines the password for the In Memory DB server configuration.
-	Password *string `json:"password,omitempty"`
+	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
 
 	// Defines the port for the In Memory DB server configuration.
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
 	// Defines the username for the In Memory DB server configuration.
-	Username *string `json:"username,omitempty"`
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
 }
 
 // Kafka Configuration
 type KafkaConfig struct {
 	// Defines the brokers the app should connect to for Kafka services.
-	Brokers []BrokerConfig `json:"brokers"`
+	Brokers []BrokerConfig `json:"brokers" yaml:"brokers" mapstructure:"brokers"`
 
 	// Defines a list of the topic configurations available to the application.
-	Topics []TopicConfig `json:"topics"`
+	Topics []TopicConfig `json:"topics" yaml:"topics" mapstructure:"topics"`
 }
 
 // SASL Configuration for Kafka
 type KafkaSASLConfig struct {
 	// Password corresponds to the JSON schema field "password".
-	Password *string `json:"password,omitempty"`
+	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
 
 	// SaslMechanism corresponds to the JSON schema field "saslMechanism".
-	SaslMechanism *string `json:"saslMechanism,omitempty"`
+	SaslMechanism *string `json:"saslMechanism,omitempty" yaml:"saslMechanism,omitempty" mapstructure:"saslMechanism,omitempty"`
 
 	// Deprecated: Use the top level securityProtocol field instead
-	SecurityProtocol *string `json:"securityProtocol,omitempty"`
+	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
 
 	// Username corresponds to the JSON schema field "username".
-	Username *string `json:"username,omitempty"`
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
 }
 
 // Logging Configuration
 type LoggingConfig struct {
 	// Cloudwatch corresponds to the JSON schema field "cloudwatch".
-	Cloudwatch *CloudWatchConfig `json:"cloudwatch,omitempty"`
+	Cloudwatch *CloudWatchConfig `json:"cloudwatch,omitempty" yaml:"cloudwatch,omitempty" mapstructure:"cloudwatch,omitempty"`
 
 	// Defines the type of logging configuration
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type" mapstructure:"type"`
 }
 
 // Object Storage Bucket
 type ObjectStoreBucket struct {
 	// Defines the access key for specificed bucket.
-	AccessKey *string `json:"accessKey,omitempty"`
+	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
 
 	// The actual name of the bucket being accessed.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
 	// Defines the region for the specified bucket.
-	Region *string `json:"region,omitempty"`
+	Region *string `json:"region,omitempty" yaml:"region,omitempty" mapstructure:"region,omitempty"`
 
 	// The name that was requested for the bucket in the ClowdApp.
-	RequestedName string `json:"requestedName"`
+	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
 
 	// Defines the secret key for the specified bucket.
-	SecretKey *string `json:"secretKey,omitempty"`
+	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
 }
 
 // Object Storage Configuration
 type ObjectStoreConfig struct {
 	// Defines the access key for the Object Storage server configuration.
-	AccessKey *string `json:"accessKey,omitempty"`
+	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
 
 	// Buckets corresponds to the JSON schema field "buckets".
-	Buckets []ObjectStoreBucket `json:"buckets,omitempty"`
+	Buckets []ObjectStoreBucket `json:"buckets,omitempty" yaml:"buckets,omitempty" mapstructure:"buckets,omitempty"`
 
 	// Defines the hostname for the Object Storage server configuration.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// Defines the port for the Object Storage server configuration.
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
 	// Defines the secret key for the Object Storage server configuration.
-	SecretKey *string `json:"secretKey,omitempty"`
+	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
 
 	// Details if the Object Server uses TLS.
-	Tls bool `json:"tls"`
+	Tls bool `json:"tls" yaml:"tls" mapstructure:"tls"`
 }
 
 // Dependent service connection info
 type PrivateDependencyEndpoint struct {
 	// The app name of the ClowdApp hosting the service.
-	App string `json:"app"`
+	App string `json:"app" yaml:"app" mapstructure:"app"`
 
 	// The hostname of the dependent service.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// The PodSpec name of the dependent service inside the ClowdApp.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
 	// The port of the dependent service.
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
 	// The TLS port of the dependent service.
-	TlsPort *int `json:"tlsPort,omitempty"`
+	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
 }
 
 // Topic Configuration
 type TopicConfig struct {
 	// The name of the actual topic on the Kafka server.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
 	// The name that the app requested in the ClowdApp definition.
-	RequestedName string `json:"requestedName"`
+	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
 }
 
 var enumValues_BrokerConfigAuthtype = []interface{}{
@@ -676,13 +679,13 @@ func (j *AppConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["logging"]; !ok || v == nil {
-		return fmt.Errorf("field logging: required")
+		return fmt.Errorf("field logging in AppConfig: required")
 	}
 	if v, ok := raw["metricsPath"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPath: required")
+		return fmt.Errorf("field metricsPath in AppConfig: required")
 	}
 	if v, ok := raw["metricsPort"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPort: required")
+		return fmt.Errorf("field metricsPort in AppConfig: required")
 	}
 	type Plain AppConfig
 	var plain Plain

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -71,6 +71,9 @@ type AppConfig struct {
 	// Defines the path to the BOPURL.
 	BOPURL *string `json:"BOPURL,omitempty" yaml:"BOPURL,omitempty" mapstructure:"BOPURL,omitempty"`
 
+	// API Path
+	ApiPath *string `json:"apiPath,omitempty" yaml:"apiPath,omitempty" mapstructure:"apiPath,omitempty"`
+
 	// Database corresponds to the JSON schema field "database".
 	Database *DatabaseConfig `json:"database,omitempty" yaml:"database,omitempty" mapstructure:"database,omitempty"`
 

--- a/sync_config.sh
+++ b/sync_config.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+# function to check if gojsonschema command is installed and if not install it
+function check_gojsonschema {
+    if ! command -v gojsonschema &> /dev/null
+    then
+        echo "gojsonschema could not be found"
+        echo "installing gojsonschema"
+        go install github.com/atombender/go-jsonschema/cmd/gojsonschema@latest
+    fi
+}
+
+check_gojsonschema
 cd pkg/api/v1
 wget https://raw.githubusercontent.com/RedHatInsights/clowder/master/controllers/cloud.redhat.com/config/schema.json -O schema.json
 gojsonschema -p v1 -o types.go schema.json

--- a/sync_config.sh
+++ b/sync_config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # function to check if gojsonschema command is installed and if not install it
-function check_gojsonschema {
+function check_and_install_gojsonschema {
     if ! command -v gojsonschema &> /dev/null
     then
         echo "gojsonschema could not be found"
@@ -10,7 +10,7 @@ function check_gojsonschema {
     fi
 }
 
-check_gojsonschema
+check_and_install_gojsonschema
 cd pkg/api/v1
 wget https://raw.githubusercontent.com/RedHatInsights/clowder/master/controllers/cloud.redhat.com/config/schema.json -O schema.json
 gojsonschema -p v1 -o types.go schema.json

--- a/tests/test.json
+++ b/tests/test.json
@@ -65,13 +65,15 @@
             "name": "endpoint1",
             "app": "app1",
             "hostname": "endpoint1.svc",
-            "port": 8000
+            "port": 8000,
+            "apiPath": "app1-api-path"
         },
         {
             "name": "endpoint2",
             "app": "app2",
             "hostname": "endpoint2.svc",
-            "port": 8000
+            "port": 8000,
+            "apiPath": "app2-api-path"
         }
     ],
     "privateEndpoints": [

--- a/tests/test.json
+++ b/tests/test.json
@@ -1,4 +1,5 @@
 {
+    "apiPath": "api-path",
     "publicPort": 8000,
     "metricsPort": 9000,
     "metricsPath": "/metrics",


### PR DESCRIPTION
This patch has 2 purposes:
* Extend the AppConfig spec to suppoer apiPath as a top level property
* Make LoadConfig public as it will now be useful in stater apps

Tests pass, but this is my first contribution so give this a critical look. 