### PR TITLE
Update for latest schema

### DIFF
--- a/pkg/api/v1/schema.json
+++ b/pkg/api/v1/schema.json
@@ -16,12 +16,20 @@
                     "description": "Defines the public port that the app should be configured to listen on for API traffic.",
                     "type": "integer"
                 },
+                "h2cPrivatePort": {
+                    "description": "Defines the private H2C port that the app should be configured to listen on for H2C traffic.",
+                    "type": "integer"
+                },
+                "h2cPublicPort": {
+                    "description": "Defines the public H2C port that the app should be configured to listen on for H2C traffic.",
+                    "type": "integer"
+                },
                 "webPort": {
                     "description": "Deprecated: Use 'publicPort' instead.",
                     "type": "integer"
                 },
                 "tlsCAPath": {
-                    "description": "Defines the port CA path",
+                    "description": "Defines path to default CA certificate for TLS connections to other ClowdApps. Only populated when TLS is enabled for entire ClowdEnvironment.",
                     "type": "string"
                 },
                 "metricsPort": {
@@ -71,9 +79,16 @@
                     "description": "Defines the path to the BOPURL.",
                     "type": "string"
                 },
+                "hashCache": {
+                    "description": "A set of configMap/secret hashes",
+                    "type": "string"
+                },
                 "hostname": {
                     "description": "The external hostname of the deployment, where applicable",
                     "type": "string"
+                },
+                "prometheusGateway": {
+                    "$ref": "#/definitions/PrometheusGatewayConfig"
                 }
             },
             "required": [
@@ -488,6 +503,18 @@
                     "description": "The TLS port of the dependent service.",
                     "type": "integer"
                 },
+                "h2cPort": {
+                    "description": "The H2C port of the dependent service.",
+                    "type": "integer"
+                },
+                "h2cTLSPort": {
+                    "description": "The H2C TLS port of the dependent service.",
+                    "type": "integer"
+                },
+                "tlsCAPath": {
+                    "description": "Defines path to CA certificate for TLS connections to this ClowdApp. If present, this should override use of default TLS CA path.",
+                    "type": "string"
+                },
                 "apiPath": {
                     "description": "The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)",
                     "type": "string"
@@ -532,6 +559,18 @@
                 "tlsPort": {
                     "description": "The TLS port of the dependent service.",
                     "type": "integer"
+                },
+                "h2cPort": {
+                    "description": "The H2C port of the dependent service.",
+                    "type": "integer"
+                },
+                "h2cTLSPort": {
+                    "description": "The H2C TLS port of the dependent service.",
+                    "type": "integer"
+                },
+                "tlsCAPath": {
+                    "description": "Defines path to CA certificate for TLS connections to this ClowdApp. If present, this should override use of default TLS CA path.",
+                    "type": "string"
                 }
             },
             "required": [
@@ -539,6 +578,25 @@
                 "hostname",
                 "port",
                 "app"
+            ]
+        },
+        "PrometheusGatewayConfig": {
+            "id": "prometheusGatewayConfig",
+            "type": "object",
+            "description": "Prometheus Gateway Configuration",
+            "properties": {
+                "hostname": {
+                    "description": "Defines the hostname for the Prometheus Gateway server configuration.",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Defines the port for the Prometheus Gateway server configuration.",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "hostname",
+                "port"
             ]
         }
     }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2,373 +2,93 @@
 
 package v1
 
-import "fmt"
 import "encoding/json"
+import "fmt"
 import "reflect"
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *TopicConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
-	}
-	type Plain TopicConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = TopicConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["adminPassword"]; !ok || v == nil {
-		return fmt.Errorf("field adminPassword: required")
-	}
-	if v, ok := raw["adminUsername"]; !ok || v == nil {
-		return fmt.Errorf("field adminUsername: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["password"]; !ok || v == nil {
-		return fmt.Errorf("field password: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["sslMode"]; !ok || v == nil {
-		return fmt.Errorf("field sslMode: required")
-	}
-	if v, ok := raw["username"]; !ok || v == nil {
-		return fmt.Errorf("field username: required")
-	}
-	type Plain DatabaseConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DatabaseConfig(plain)
-	return nil
-}
 
 // ClowdApp deployment configuration for Clowder enabled apps.
 type AppConfig struct {
 	// Defines the path to the BOPURL.
-	BOPURL *string `json:"BOPURL,omitempty"`
+	BOPURL *string `json:"BOPURL,omitempty" yaml:"BOPURL,omitempty" mapstructure:"BOPURL,omitempty"`
 
 	// Database corresponds to the JSON schema field "database".
-	Database *DatabaseConfig `json:"database,omitempty"`
+	Database *DatabaseConfig `json:"database,omitempty" yaml:"database,omitempty" mapstructure:"database,omitempty"`
 
 	// Endpoints corresponds to the JSON schema field "endpoints".
-	Endpoints []DependencyEndpoint `json:"endpoints,omitempty"`
+	Endpoints []DependencyEndpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty" mapstructure:"endpoints,omitempty"`
 
 	// FeatureFlags corresponds to the JSON schema field "featureFlags".
-	FeatureFlags *FeatureFlagsConfig `json:"featureFlags,omitempty"`
+	FeatureFlags *FeatureFlagsConfig `json:"featureFlags,omitempty" yaml:"featureFlags,omitempty" mapstructure:"featureFlags,omitempty"`
+
+	// Defines the private H2C port that the app should be configured to listen on for
+	// H2C traffic.
+	H2CPrivatePort *int `json:"h2cPrivatePort,omitempty" yaml:"h2cPrivatePort,omitempty" mapstructure:"h2cPrivatePort,omitempty"`
+
+	// Defines the public H2C port that the app should be configured to listen on for
+	// H2C traffic.
+	H2CPublicPort *int `json:"h2cPublicPort,omitempty" yaml:"h2cPublicPort,omitempty" mapstructure:"h2cPublicPort,omitempty"`
+
+	// A set of configMap/secret hashes
+	HashCache *string `json:"hashCache,omitempty" yaml:"hashCache,omitempty" mapstructure:"hashCache,omitempty"`
 
 	// The external hostname of the deployment, where applicable
-	Hostname *string `json:"hostname,omitempty"`
+	Hostname *string `json:"hostname,omitempty" yaml:"hostname,omitempty" mapstructure:"hostname,omitempty"`
 
 	// InMemoryDb corresponds to the JSON schema field "inMemoryDb".
-	InMemoryDb *InMemoryDBConfig `json:"inMemoryDb,omitempty"`
+	InMemoryDb *InMemoryDBConfig `json:"inMemoryDb,omitempty" yaml:"inMemoryDb,omitempty" mapstructure:"inMemoryDb,omitempty"`
 
 	// Kafka corresponds to the JSON schema field "kafka".
-	Kafka *KafkaConfig `json:"kafka,omitempty"`
+	Kafka *KafkaConfig `json:"kafka,omitempty" yaml:"kafka,omitempty" mapstructure:"kafka,omitempty"`
 
 	// Logging corresponds to the JSON schema field "logging".
-	Logging LoggingConfig `json:"logging"`
+	Logging LoggingConfig `json:"logging" yaml:"logging" mapstructure:"logging"`
 
 	// Metadata corresponds to the JSON schema field "metadata".
-	Metadata *AppMetadata `json:"metadata,omitempty"`
+	Metadata *AppMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata,omitempty"`
 
 	// Defines the path to the metrics server that the app should be configured to
 	// listen on for metric traffic.
-	MetricsPath string `json:"metricsPath"`
+	MetricsPath string `json:"metricsPath" yaml:"metricsPath" mapstructure:"metricsPath"`
 
 	// Defines the metrics port that the app should be configured to listen on for
 	// metric traffic.
-	MetricsPort int `json:"metricsPort"`
+	MetricsPort int `json:"metricsPort" yaml:"metricsPort" mapstructure:"metricsPort"`
 
 	// ObjectStore corresponds to the JSON schema field "objectStore".
-	ObjectStore *ObjectStoreConfig `json:"objectStore,omitempty"`
+	ObjectStore *ObjectStoreConfig `json:"objectStore,omitempty" yaml:"objectStore,omitempty" mapstructure:"objectStore,omitempty"`
 
 	// PrivateEndpoints corresponds to the JSON schema field "privateEndpoints".
-	PrivateEndpoints []PrivateDependencyEndpoint `json:"privateEndpoints,omitempty"`
+	PrivateEndpoints []PrivateDependencyEndpoint `json:"privateEndpoints,omitempty" yaml:"privateEndpoints,omitempty" mapstructure:"privateEndpoints,omitempty"`
 
 	// Defines the private port that the app should be configured to listen on for API
 	// traffic.
-	PrivatePort *int `json:"privatePort,omitempty"`
+	PrivatePort *int `json:"privatePort,omitempty" yaml:"privatePort,omitempty" mapstructure:"privatePort,omitempty"`
+
+	// PrometheusGateway corresponds to the JSON schema field "prometheusGateway".
+	PrometheusGateway *PrometheusGatewayConfig `json:"prometheusGateway,omitempty" yaml:"prometheusGateway,omitempty" mapstructure:"prometheusGateway,omitempty"`
 
 	// Defines the public port that the app should be configured to listen on for API
 	// traffic.
-	PublicPort *int `json:"publicPort,omitempty"`
+	PublicPort *int `json:"publicPort,omitempty" yaml:"publicPort,omitempty" mapstructure:"publicPort,omitempty"`
 
-	// Defines the port CA path
-	TlsCAPath *string `json:"tlsCAPath,omitempty"`
+	// Defines path to default CA certificate for TLS connections to other ClowdApps.
+	// Only populated when TLS is enabled for entire ClowdEnvironment.
+	TlsCAPath *string `json:"tlsCAPath,omitempty" yaml:"tlsCAPath,omitempty" mapstructure:"tlsCAPath,omitempty"`
 
 	// Deprecated: Use 'publicPort' instead.
-	WebPort *int `json:"webPort,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["apiPath"]; !ok || v == nil {
-		return fmt.Errorf("field apiPath: required")
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain DependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DependencyEndpoint(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain PrivateDependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = PrivateDependencyEndpoint(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["tls"]; !ok || v == nil {
-		return fmt.Errorf("field tls: required")
-	}
-	type Plain ObjectStoreConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ObjectStoreConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_FeatureFlagsConfigScheme {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
-	}
-	*j = FeatureFlagsConfigScheme(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
-	}
-	type Plain ObjectStoreBucket
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ObjectStoreBucket(plain)
-	return nil
+	WebPort *int `json:"webPort,omitempty" yaml:"webPort,omitempty" mapstructure:"webPort,omitempty"`
 }
 
 // Arbitrary metadata pertaining to the application application
 type AppMetadata struct {
 	// Metadata pertaining to an application's deployments
-	Deployments []DeploymentMetadata `json:"deployments,omitempty"`
+	Deployments []DeploymentMetadata `json:"deployments,omitempty" yaml:"deployments,omitempty" mapstructure:"deployments,omitempty"`
 
 	// Name of the ClowdEnvironment this ClowdApp runs in
-	EnvName *string `json:"envName,omitempty"`
+	EnvName *string `json:"envName,omitempty" yaml:"envName,omitempty" mapstructure:"envName,omitempty"`
 
 	// Name of the ClowdApp
-	Name *string `json:"name,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["image"]; !ok || v == nil {
-		return fmt.Errorf("field image: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	type Plain DeploymentMetadata
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DeploymentMetadata(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["scheme"]; !ok || v == nil {
-		return fmt.Errorf("field scheme: required")
-	}
-	type Plain FeatureFlagsConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = FeatureFlagsConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type: required")
-	}
-	type Plain LoggingConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = LoggingConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain InMemoryDBConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = InMemoryDBConfig(plain)
-	return nil
-}
-
-type BrokerConfigAuthtype string
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["accessKeyId"]; !ok || v == nil {
-		return fmt.Errorf("field accessKeyId: required")
-	}
-	if v, ok := raw["logGroup"]; !ok || v == nil {
-		return fmt.Errorf("field logGroup: required")
-	}
-	if v, ok := raw["region"]; !ok || v == nil {
-		return fmt.Errorf("field region: required")
-	}
-	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
-		return fmt.Errorf("field secretAccessKey: required")
-	}
-	type Plain CloudWatchConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = CloudWatchConfig(plain)
-	return nil
+	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -391,43 +111,233 @@ func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["apiPath"]; !ok || v == nil {
+		return fmt.Errorf("field apiPath in DependencyEndpoint: required")
+	}
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app in DependencyEndpoint: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in DependencyEndpoint: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in DependencyEndpoint: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in DependencyEndpoint: required")
+	}
+	type Plain DependencyEndpoint
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DependencyEndpoint(plain)
+	return nil
+}
+
+type FeatureFlagsConfigScheme string
+
+var enumValues_FeatureFlagsConfigScheme = []interface{}{
+	"http",
+	"https",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_FeatureFlagsConfigScheme {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
+	}
+	*j = FeatureFlagsConfigScheme(v)
+	return nil
+}
+
+const FeatureFlagsConfigSchemeHttp FeatureFlagsConfigScheme = "http"
+const FeatureFlagsConfigSchemeHttps FeatureFlagsConfigScheme = "https"
+
+// Feature Flags Configuration
+type FeatureFlagsConfig struct {
+	// Defines the client access token to use when connect to the FeatureFlags server
+	ClientAccessToken *string `json:"clientAccessToken,omitempty" yaml:"clientAccessToken,omitempty" mapstructure:"clientAccessToken,omitempty"`
+
+	// Defines the hostname for the FeatureFlags server
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// Defines the port for the FeatureFlags server
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Details the scheme to use for FeatureFlags http/https
+	Scheme FeatureFlagsConfigScheme `json:"scheme" yaml:"scheme" mapstructure:"scheme"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in FeatureFlagsConfig: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in FeatureFlagsConfig: required")
+	}
+	if v, ok := raw["scheme"]; !ok || v == nil {
+		return fmt.Errorf("field scheme in FeatureFlagsConfig: required")
+	}
+	type Plain FeatureFlagsConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = FeatureFlagsConfig(plain)
+	return nil
+}
+
+// In Memory DB Configuration
+type InMemoryDBConfig struct {
+	// Defines the hostname for the In Memory DB server configuration.
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// Defines the password for the In Memory DB server configuration.
+	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
+
+	// Defines the port for the In Memory DB server configuration.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Defines the sslMode used by the In Memory DB server coniguration
+	SslMode *bool `json:"sslMode,omitempty" yaml:"sslMode,omitempty" mapstructure:"sslMode,omitempty"`
+
+	// Defines the username for the In Memory DB server configuration.
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in InMemoryDBConfig: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in InMemoryDBConfig: required")
+	}
+	type Plain InMemoryDBConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = InMemoryDBConfig(plain)
+	return nil
+}
+
+type BrokerConfigAuthtype string
+
+var enumValues_BrokerConfigAuthtype = []interface{}{
+	"sasl",
+}
+
+// Topic Configuration
+type TopicConfig struct {
+	// The name of the actual topic on the Kafka server.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// The name that the app requested in the ClowdApp definition.
+	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
+}
+
 const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
 
-// Cloud Watch configuration
-type CloudWatchConfig struct {
-	// Defines the access key that the app should use for configuring CloudWatch.
-	AccessKeyId string `json:"accessKeyId"`
+// SASL Configuration for Kafka
+type KafkaSASLConfig struct {
+	// Broker SASL password
+	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
 
-	// Defines the logGroup that the app should use for configuring CloudWatch.
-	LogGroup string `json:"logGroup"`
+	// Broker SASL mechanism, expect: SCRAM-SHA-512
+	SaslMechanism *string `json:"saslMechanism,omitempty" yaml:"saslMechanism,omitempty" mapstructure:"saslMechanism,omitempty"`
 
-	// Defines the region that the app should use for configuring CloudWatch.
-	Region string `json:"region"`
+	// Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use
+	// the top level securityProtocol field instead
+	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
 
-	// Defines the secret key that the app should use for configuring CloudWatch.
-	SecretAccessKey string `json:"secretAccessKey"`
+	// Broker SASL username
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
 }
 
 // Broker Configuration
 type BrokerConfig struct {
 	// Authtype corresponds to the JSON schema field "authtype".
-	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty"`
+	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty" yaml:"authtype,omitempty" mapstructure:"authtype,omitempty"`
 
 	// CA certificate trust list for broker in PEM format. If absent, client should
 	// use OS default trust list
-	Cacert *string `json:"cacert,omitempty"`
+	Cacert *string `json:"cacert,omitempty" yaml:"cacert,omitempty" mapstructure:"cacert,omitempty"`
 
 	// Hostname of kafka broker
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// Port of kafka broker
-	Port *int `json:"port,omitempty"`
+	Port *int `json:"port,omitempty" yaml:"port,omitempty" mapstructure:"port,omitempty"`
 
 	// Sasl corresponds to the JSON schema field "sasl".
-	Sasl *KafkaSASLConfig `json:"sasl,omitempty"`
+	Sasl *KafkaSASLConfig `json:"sasl,omitempty" yaml:"sasl,omitempty" mapstructure:"sasl,omitempty"`
 
 	// Broker security procotol, expect one of either: SASL_SSL, SSL
-	SecurityProtocol *string `json:"securityProtocol,omitempty"`
+	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
+}
+
+// Dependent service connection info
+type DependencyEndpoint struct {
+	// The top level api path that the app should serve from /api/<apiPath>
+	// (deprecated, use apiPaths)
+	ApiPath string `json:"apiPath" yaml:"apiPath" mapstructure:"apiPath"`
+
+	// The list of API paths (each matching format: '/api/some-path/') that this app
+	// will serve requests from
+	ApiPaths []string `json:"apiPaths,omitempty" yaml:"apiPaths,omitempty" mapstructure:"apiPaths,omitempty"`
+
+	// The app name of the ClowdApp hosting the service.
+	App string `json:"app" yaml:"app" mapstructure:"app"`
+
+	// The H2C port of the dependent service.
+	H2CPort *int `json:"h2cPort,omitempty" yaml:"h2cPort,omitempty" mapstructure:"h2cPort,omitempty"`
+
+	// The H2C TLS port of the dependent service.
+	H2CTLSPort *int `json:"h2cTLSPort,omitempty" yaml:"h2cTLSPort,omitempty" mapstructure:"h2cTLSPort,omitempty"`
+
+	// The hostname of the dependent service.
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// The PodSpec name of the dependent service inside the ClowdApp.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// The port of the dependent service.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Defines path to CA certificate for TLS connections to this ClowdApp. If
+	// present, this should override use of default TLS CA path.
+	TlsCAPath *string `json:"tlsCAPath,omitempty" yaml:"tlsCAPath,omitempty" mapstructure:"tlsCAPath,omitempty"`
+
+	// The TLS port of the dependent service.
+	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -437,7 +347,7 @@ func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
+		return fmt.Errorf("field hostname in BrokerConfig: required")
 	}
 	type Plain BrokerConfig
 	var plain Plain
@@ -448,6 +358,24 @@ func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// Logging Configuration
+type LoggingConfig struct {
+	// Cloudwatch corresponds to the JSON schema field "cloudwatch".
+	Cloudwatch *CloudWatchConfig `json:"cloudwatch,omitempty" yaml:"cloudwatch,omitempty" mapstructure:"cloudwatch,omitempty"`
+
+	// Defines the type of logging configuration
+	Type string `json:"type" yaml:"type" mapstructure:"type"`
+}
+
+// Kafka Configuration
+type KafkaConfig struct {
+	// Defines the brokers the app should connect to for Kafka services.
+	Brokers []BrokerConfig `json:"brokers" yaml:"brokers" mapstructure:"brokers"`
+
+	// Defines a list of the topic configurations available to the application.
+	Topics []TopicConfig `json:"topics" yaml:"topics" mapstructure:"topics"`
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
@@ -455,10 +383,10 @@ func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["brokers"]; !ok || v == nil {
-		return fmt.Errorf("field brokers: required")
+		return fmt.Errorf("field brokers in KafkaConfig: required")
 	}
 	if v, ok := raw["topics"]; !ok || v == nil {
-		return fmt.Errorf("field topics: required")
+		return fmt.Errorf("field topics in KafkaConfig: required")
 	}
 	type Plain KafkaConfig
 	var plain Plain
@@ -469,221 +397,359 @@ func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Database Configuration
-type DatabaseConfig struct {
-	// Defines the pgAdmin password.
-	AdminPassword string `json:"adminPassword"`
+// Cloud Watch configuration
+type CloudWatchConfig struct {
+	// Defines the access key that the app should use for configuring CloudWatch.
+	AccessKeyId string `json:"accessKeyId" yaml:"accessKeyId" mapstructure:"accessKeyId"`
 
-	// Defines the pgAdmin username.
-	AdminUsername string `json:"adminUsername"`
+	// Defines the logGroup that the app should use for configuring CloudWatch.
+	LogGroup string `json:"logGroup" yaml:"logGroup" mapstructure:"logGroup"`
 
-	// Defines the hostname of the database configured for the ClowdApp.
-	Hostname string `json:"hostname"`
+	// Defines the region that the app should use for configuring CloudWatch.
+	Region string `json:"region" yaml:"region" mapstructure:"region"`
 
-	// Defines the database name.
-	Name string `json:"name"`
-
-	// Defines the password for the standard user.
-	Password string `json:"password"`
-
-	// Defines the port of the database configured for the ClowdApp.
-	Port int `json:"port"`
-
-	// Defines the CA used to access the database.
-	RdsCa *string `json:"rdsCa,omitempty"`
-
-	// Defines the postgres SSL mode that should be used.
-	SslMode string `json:"sslMode"`
-
-	// Defines a username with standard access to the database.
-	Username string `json:"username"`
+	// Defines the secret key that the app should use for configuring CloudWatch.
+	SecretAccessKey string `json:"secretAccessKey" yaml:"secretAccessKey" mapstructure:"secretAccessKey"`
 }
 
-// Dependent service connection info
-type DependencyEndpoint struct {
-	// The top level api path that the app should serve from /api/<apiPath>
-	// (deprecated, use apiPaths)
-	ApiPath string `json:"apiPath"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["accessKeyId"]; !ok || v == nil {
+		return fmt.Errorf("field accessKeyId in CloudWatchConfig: required")
+	}
+	if v, ok := raw["logGroup"]; !ok || v == nil {
+		return fmt.Errorf("field logGroup in CloudWatchConfig: required")
+	}
+	if v, ok := raw["region"]; !ok || v == nil {
+		return fmt.Errorf("field region in CloudWatchConfig: required")
+	}
+	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
+		return fmt.Errorf("field secretAccessKey in CloudWatchConfig: required")
+	}
+	type Plain CloudWatchConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = CloudWatchConfig(plain)
+	return nil
+}
 
-	// The list of API paths (each matching format: '/api/some-path/') that this app
-	// will serve requests from
-	ApiPaths []string `json:"apiPaths,omitempty"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *TopicConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in TopicConfig: required")
+	}
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName in TopicConfig: required")
+	}
+	type Plain TopicConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = TopicConfig(plain)
+	return nil
+}
 
-	// The app name of the ClowdApp hosting the service.
-	App string `json:"app"`
-
-	// The hostname of the dependent service.
-	Hostname string `json:"hostname"`
-
-	// The PodSpec name of the dependent service inside the ClowdApp.
-	Name string `json:"name"`
-
-	// The port of the dependent service.
-	Port int `json:"port"`
-
-	// The TLS port of the dependent service.
-	TlsPort *int `json:"tlsPort,omitempty"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in LoggingConfig: required")
+	}
+	type Plain LoggingConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = LoggingConfig(plain)
+	return nil
 }
 
 // Deployment Metadata
 type DeploymentMetadata struct {
 	// Image used by deployment
-	Image string `json:"image"`
+	Image string `json:"image" yaml:"image" mapstructure:"image"`
 
 	// Name of deployment
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 }
 
-// Feature Flags Configuration
-type FeatureFlagsConfig struct {
-	// Defines the client access token to use when connect to the FeatureFlags server
-	ClientAccessToken *string `json:"clientAccessToken,omitempty"`
-
-	// Defines the hostname for the FeatureFlags server
-	Hostname string `json:"hostname"`
-
-	// Defines the port for the FeatureFlags server
-	Port int `json:"port"`
-
-	// Details the scheme to use for FeatureFlags http/https
-	Scheme FeatureFlagsConfigScheme `json:"scheme"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["image"]; !ok || v == nil {
+		return fmt.Errorf("field image in DeploymentMetadata: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in DeploymentMetadata: required")
+	}
+	type Plain DeploymentMetadata
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DeploymentMetadata(plain)
+	return nil
 }
 
-type FeatureFlagsConfigScheme string
+// Database Configuration
+type DatabaseConfig struct {
+	// Defines the pgAdmin password.
+	AdminPassword string `json:"adminPassword" yaml:"adminPassword" mapstructure:"adminPassword"`
 
-const FeatureFlagsConfigSchemeHttp FeatureFlagsConfigScheme = "http"
-const FeatureFlagsConfigSchemeHttps FeatureFlagsConfigScheme = "https"
+	// Defines the pgAdmin username.
+	AdminUsername string `json:"adminUsername" yaml:"adminUsername" mapstructure:"adminUsername"`
 
-// In Memory DB Configuration
-type InMemoryDBConfig struct {
-	// Defines the hostname for the In Memory DB server configuration.
-	Hostname string `json:"hostname"`
+	// Defines the hostname of the database configured for the ClowdApp.
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
-	// Defines the password for the In Memory DB server configuration.
-	Password *string `json:"password,omitempty"`
+	// Defines the database name.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
-	// Defines the port for the In Memory DB server configuration.
-	Port int `json:"port"`
+	// Defines the password for the standard user.
+	Password string `json:"password" yaml:"password" mapstructure:"password"`
 
-	// Defines the sslMode used by the In Memory DB server coniguration
-	SslMode *bool `json:"sslMode,omitempty"`
+	// Defines the port of the database configured for the ClowdApp.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
-	// Defines the username for the In Memory DB server configuration.
-	Username *string `json:"username,omitempty"`
-}
+	// Defines the CA used to access the database.
+	RdsCa *string `json:"rdsCa,omitempty" yaml:"rdsCa,omitempty" mapstructure:"rdsCa,omitempty"`
 
-// Kafka Configuration
-type KafkaConfig struct {
-	// Defines the brokers the app should connect to for Kafka services.
-	Brokers []BrokerConfig `json:"brokers"`
+	// Defines the postgres SSL mode that should be used.
+	SslMode string `json:"sslMode" yaml:"sslMode" mapstructure:"sslMode"`
 
-	// Defines a list of the topic configurations available to the application.
-	Topics []TopicConfig `json:"topics"`
-}
-
-// SASL Configuration for Kafka
-type KafkaSASLConfig struct {
-	// Broker SASL password
-	Password *string `json:"password,omitempty"`
-
-	// Broker SASL mechanism, expect: SCRAM-SHA-512
-	SaslMechanism *string `json:"saslMechanism,omitempty"`
-
-	// Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use
-	// the top level securityProtocol field instead
-	SecurityProtocol *string `json:"securityProtocol,omitempty"`
-
-	// Broker SASL username
-	Username *string `json:"username,omitempty"`
-}
-
-// Logging Configuration
-type LoggingConfig struct {
-	// Cloudwatch corresponds to the JSON schema field "cloudwatch".
-	Cloudwatch *CloudWatchConfig `json:"cloudwatch,omitempty"`
-
-	// Defines the type of logging configuration
-	Type string `json:"type"`
+	// Defines a username with standard access to the database.
+	Username string `json:"username" yaml:"username" mapstructure:"username"`
 }
 
 // Object Storage Bucket
 type ObjectStoreBucket struct {
 	// Defines the access key for specificed bucket.
-	AccessKey *string `json:"accessKey,omitempty"`
+	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
 
 	// Defines the endpoint for the Object Storage server configuration.
-	Endpoint *string `json:"endpoint,omitempty"`
+	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty" mapstructure:"endpoint,omitempty"`
 
 	// The actual name of the bucket being accessed.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
 	// Defines the region for the specified bucket.
-	Region *string `json:"region,omitempty"`
+	Region *string `json:"region,omitempty" yaml:"region,omitempty" mapstructure:"region,omitempty"`
 
 	// The name that was requested for the bucket in the ClowdApp.
-	RequestedName string `json:"requestedName"`
+	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
 
 	// Defines the secret key for the specified bucket.
-	SecretKey *string `json:"secretKey,omitempty"`
+	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
 
 	// Details if the Object Server uses TLS.
-	Tls *bool `json:"tls,omitempty"`
+	Tls *bool `json:"tls,omitempty" yaml:"tls,omitempty" mapstructure:"tls,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in ObjectStoreBucket: required")
+	}
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName in ObjectStoreBucket: required")
+	}
+	type Plain ObjectStoreBucket
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ObjectStoreBucket(plain)
+	return nil
 }
 
 // Object Storage Configuration
 type ObjectStoreConfig struct {
 	// Defines the access key for the Object Storage server configuration.
-	AccessKey *string `json:"accessKey,omitempty"`
+	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
 
 	// Buckets corresponds to the JSON schema field "buckets".
-	Buckets []ObjectStoreBucket `json:"buckets,omitempty"`
+	Buckets []ObjectStoreBucket `json:"buckets,omitempty" yaml:"buckets,omitempty" mapstructure:"buckets,omitempty"`
 
 	// Defines the hostname for the Object Storage server configuration.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// Defines the port for the Object Storage server configuration.
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
 	// Defines the secret key for the Object Storage server configuration.
-	SecretKey *string `json:"secretKey,omitempty"`
+	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
 
 	// Details if the Object Server uses TLS.
-	Tls bool `json:"tls"`
+	Tls bool `json:"tls" yaml:"tls" mapstructure:"tls"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in ObjectStoreConfig: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in ObjectStoreConfig: required")
+	}
+	if v, ok := raw["tls"]; !ok || v == nil {
+		return fmt.Errorf("field tls in ObjectStoreConfig: required")
+	}
+	type Plain ObjectStoreConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ObjectStoreConfig(plain)
+	return nil
 }
 
 // Dependent service connection info
 type PrivateDependencyEndpoint struct {
 	// The app name of the ClowdApp hosting the service.
-	App string `json:"app"`
+	App string `json:"app" yaml:"app" mapstructure:"app"`
+
+	// The H2C port of the dependent service.
+	H2CPort *int `json:"h2cPort,omitempty" yaml:"h2cPort,omitempty" mapstructure:"h2cPort,omitempty"`
+
+	// The H2C TLS port of the dependent service.
+	H2CTLSPort *int `json:"h2cTLSPort,omitempty" yaml:"h2cTLSPort,omitempty" mapstructure:"h2cTLSPort,omitempty"`
 
 	// The hostname of the dependent service.
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
 
 	// The PodSpec name of the dependent service inside the ClowdApp.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
 	// The port of the dependent service.
-	Port int `json:"port"`
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Defines path to CA certificate for TLS connections to this ClowdApp. If
+	// present, this should override use of default TLS CA path.
+	TlsCAPath *string `json:"tlsCAPath,omitempty" yaml:"tlsCAPath,omitempty" mapstructure:"tlsCAPath,omitempty"`
 
 	// The TLS port of the dependent service.
-	TlsPort *int `json:"tlsPort,omitempty"`
+	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
 }
 
-// Topic Configuration
-type TopicConfig struct {
-	// The name of the actual topic on the Kafka server.
-	Name string `json:"name"`
-
-	// The name that the app requested in the ClowdApp definition.
-	RequestedName string `json:"requestedName"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app in PrivateDependencyEndpoint: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in PrivateDependencyEndpoint: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in PrivateDependencyEndpoint: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in PrivateDependencyEndpoint: required")
+	}
+	type Plain PrivateDependencyEndpoint
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = PrivateDependencyEndpoint(plain)
+	return nil
 }
 
-var enumValues_BrokerConfigAuthtype = []interface{}{
-	"sasl",
+// Prometheus Gateway Configuration
+type PrometheusGatewayConfig struct {
+	// Defines the hostname for the Prometheus Gateway server configuration.
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// Defines the port for the Prometheus Gateway server configuration.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 }
-var enumValues_FeatureFlagsConfigScheme = []interface{}{
-	"http",
-	"https",
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *PrometheusGatewayConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in PrometheusGatewayConfig: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in PrometheusGatewayConfig: required")
+	}
+	type Plain PrometheusGatewayConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = PrometheusGatewayConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["adminPassword"]; !ok || v == nil {
+		return fmt.Errorf("field adminPassword in DatabaseConfig: required")
+	}
+	if v, ok := raw["adminUsername"]; !ok || v == nil {
+		return fmt.Errorf("field adminUsername in DatabaseConfig: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in DatabaseConfig: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in DatabaseConfig: required")
+	}
+	if v, ok := raw["password"]; !ok || v == nil {
+		return fmt.Errorf("field password in DatabaseConfig: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in DatabaseConfig: required")
+	}
+	if v, ok := raw["sslMode"]; !ok || v == nil {
+		return fmt.Errorf("field sslMode in DatabaseConfig: required")
+	}
+	if v, ok := raw["username"]; !ok || v == nil {
+		return fmt.Errorf("field username in DatabaseConfig: required")
+	}
+	type Plain DatabaseConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DatabaseConfig(plain)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -693,13 +759,13 @@ func (j *AppConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["logging"]; !ok || v == nil {
-		return fmt.Errorf("field logging: required")
+		return fmt.Errorf("field logging in AppConfig: required")
 	}
 	if v, ok := raw["metricsPath"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPath: required")
+		return fmt.Errorf("field metricsPath in AppConfig: required")
 	}
 	if v, ok := raw["metricsPort"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPort: required")
+		return fmt.Errorf("field metricsPort in AppConfig: required")
 	}
 	type Plain AppConfig
 	var plain Plain


### PR DESCRIPTION
Incorporates new features added to schema:

H2C port support: Added h2cPrivatePort and h2cPublicPort to AppConfig for HTTP/2 Cleartext traffic handling
Prometheus Gateway configuration: New PrometheusGatewayConfig class with hostname and port configuration in AppConfig
Enhanced TLS paths: Added tlsCAPath to both DependencyEndpoint and PrivateDependencyEndpoint for custom CA certificate paths per ClowdApp
Hash cache: Added hashCache field to AppConfig for configMap/secret hash tracking
H2C endpoint support: Added h2cPort and h2cTLSPort to dependency endpoint types